### PR TITLE
Fix Write-Log refactor

### DIFF
--- a/Delete-Device.ps1
+++ b/Delete-Device.ps1
@@ -13,9 +13,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.0
+  Version:        1.1
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  10/02/2021
+  Updated Date:   10/08/2021
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Delete-Device.ps1 -file "Devices.csv" -fileColumn "SerialNumber"
@@ -36,7 +37,7 @@ Import-Module .\PSairwatch.psm1
 $Logfile = "$PSScriptRoot\DeleteDevice.log"
 $list = Read-File $file $fileColumn
 
-Write-Log "$($MyInvocation.Line)"
+Write-Log -logstring "$($MyInvocation.Line)" -logfile $Logfile
 
 $decision = $Host.UI.PromptForChoice(
     "Attention! If you proceed, " + $list.count + " device records will be deleted from Workspace ONE UEM",
@@ -44,10 +45,10 @@ $decision = $Host.UI.PromptForChoice(
     @('&Yes', '&No'), 1)
 
 if ($decision -eq 0) {
-    Write-Log "Wiping $($list.count) devices deleted from Workspace ONE UEM"
+    Write-Log -logstring "Wiping $($list.count) devices deleted from Workspace ONE UEM" -logfile $Logfile
     $json = ' '
 
-    $DeletedDevices = Remove-DeviceBulk $DeviceJSON
+    #$DeletedDevices = Remove-DeviceBulk $DeviceJSON
 
     foreach ($item in $list) {
         Write-Progress -Activity "Deleting Devices..." -Status "Batch $($list.IndexOf($item)+1) of $($list.Count)" -CurrentOperation "$item" -PercentComplete ((($list.IndexOf($list)+1)/($list.Count))*100)
@@ -56,19 +57,19 @@ if ($decision -eq 0) {
             $result = Send-Delete -endpoint $endpointURL -body $json -version "application/json;version=1"
             if ($result -ne "") {
                 Write-Warning "Error Deleting Device: $item :$result"
-                Write-Log "Error Deleting Device: $item :$result"
+                Write-Log -logstring "Error Deleting Device: $item :$result" -logfile $Logfile
             } else {
                 Write-Host "$item Deleted $result"
-                Write-Log "$item Deleted $result"
+                Write-Log -logstring "$item Deleted $result" -logfile $Logfile
             }
         }
         catch {
             Write-Warning "Error Deleting: $item"
-            Write-Log "Error Deleting: $item"
+            Write-Log -logstring "Error Deleting: $item" -logfile $Logfile
         }
     }
 } else {
     Write-Host "Delete Cancelled"
-    Write-Log "Delete Cancelled"
+    Write-Log -logstring "Delete Cancelled" -logfile $Logfile
 }
 

--- a/Delete-Profile.ps1
+++ b/Delete-Profile.ps1
@@ -13,10 +13,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.1
+  Version:        1.2
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  01/09/2021
-  Update Date:    10/02/2021
+  Update Date:    10/08/2021
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   Delete-Profile.ps1 -file .\ProfilesTest.csv -fileColumn "ProfileId"
@@ -38,7 +38,7 @@ $Logfile = "$PSScriptRoot\ProfileDelete.log"
 
 $list = Read-File $file $fileColumn
 
-Write-Log "$($MyInvocation.Line)"
+Write-Log -logstring "$($MyInvocation.Line)" -logfile $Logfile
 
 $decision = $Host.UI.PromptForChoice(
     "Attention! If you proceed, " + $list.count + " profiles will be deleted from AirWatch",
@@ -46,7 +46,7 @@ $decision = $Host.UI.PromptForChoice(
     @('&Yes', '&No'), 1)
 
 if ($decision -eq 0) {
-    Write-Log "Deleting $($list.count) profiles from AirWatch"
+    Write-Log -logstring "Deleting $($list.count) profiles from AirWatch" -logfile $Logfile
 
     foreach ($item in $list) {
         Write-Progress -Activity "Deleting Profiles..." -Status "Profile $($list.IndexOf($item)+1) of $($list.Count)" -CurrentOperation "$item" -PercentComplete ((($list.IndexOf($list)+1)/($list.Count))*100)
@@ -55,19 +55,19 @@ if ($decision -eq 0) {
             $result = Send-Delete -endpoint $endpointURL -version "application/json;version=1"
             if ($result -ne "") {
                     Write-Warning ("Error Deleting Profile: $item : $result")
-                    Write-Log ("Error Deleting Profile: $item : $result")
+                    Write-Log -logstring ("Error Deleting Profile: $item : $result") -logfile $Logfile
             } else {
                 Write-Host "$item Deleted $result"
-                Write-Log "$item Deleted $result"
+                Write-Log -logstring "$item Deleted $result" -logfile $Logfile
             }
         }
         catch {
           $err2 = $Error[0].ErrorDetails.Message
           Write-Warning "Error Sending Profile Delete Command: $item $err2"
-          Write-Log "Error Sending Profile Delete Command: $item $err2"
+          Write-Log -logstring "Error Sending Profile Delete Command: $item $err2" -logfile $Logfile
         }
     }
 } else {
     Write-Host "Deletion Cancelled"
-    Write-Log "Deletion Cancelled"
+    Write-Log -logstring "Deletion Cancelled" -logfile $Logfile
 }

--- a/Get-DeviceDetails.ps1
+++ b/Get-DeviceDetails.ps1
@@ -15,10 +15,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.1
+  Version:        1.2
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  01/08/2021
-  Update Date:    10/02/2021
+  Update Date:    10/08/2021
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Get-DeviceDetails.ps1 -file "Devices.csv" -fileColumn "SerialNumber"
@@ -43,8 +43,8 @@ $Logfile = "$PSScriptRoot\DeviceDetails.log"
 
 $list = Read-File $file $fileColumn
 
-Write-Log "$($MyInvocation.Line)"
-Write-Log "Getting Device Details for $($list.count) devices in AirWatch"
+Write-Log -logstring "$($MyInvocation.Line)" -logfile $Logfile
+Write-Log -logstring "Getting Device Details for $($list.count) devices in AirWatch" -logfile $Logfile
 $date = Get-Date -Format yyyyMMdd
 $endpointURL = "mdm/devices?searchBy=$searchBy"
 $DeviceJSON = Set-AddTagJSON $list
@@ -53,11 +53,11 @@ try {
     if ($results) {
         $results.Devices | Export-Csv -Path "DevicesDetails${date}.csv"
     } else {
-        Write-Log "No Results"
+        Write-Log -logstring "No Results" -logfile $Logfile
     }
 }
 catch {
-    Write-Log "Error (maybe no results)"
+    Write-Log -logstring "Error (maybe no results)" -logfile $Logfile
 }
 
 

--- a/Get-Profile.ps1
+++ b/Get-Profile.ps1
@@ -12,10 +12,10 @@
 .OUTPUTS
   Outputs a CSV: "Profiles[today's date].csv"
 .NOTES
-  Version:        1.1
+  Version:        1.2
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  01/09/2021
-  Update Date:    10/02/2021
+  Update Date:    10/08/2021
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Get-Profile.ps1 -query "status=Active&platform=Apple"
@@ -32,8 +32,8 @@ Import-Module .\PSairwatch.psm1
 
 $Logfile = "$PSScriptRoot\Profiles.log"
 
-Write-Log "$($MyInvocation.Line)"
-Write-Log "Getting Profiles in AirWatch"
+Write-Log -logstring "$($MyInvocation.Line)" -logfile $Logfile
+Write-Log -logstring "Getting Profiles in AirWatch" -logfile $Logfile
 $date = Get-Date -Format yyyyMMdd
 if ($query) {
   $endpointURL = "mdm/profiles/search?$query"
@@ -41,16 +41,16 @@ if ($query) {
   $endpointURL = "mdm/profiles/search"
 }
 $results = Send-Get -endpoint $endpointURL -version "application/json;version=2"
+
 try {
-    if ($results) {
-        Write-Log "$($results.ProfileList.Length) Profiles returned out of $($results.TotalResults) total, writing csv."
-        $results.ProfileList | Export-Csv -Path "Profiles${date}.csv"
-    } else {
-        Write-Log "No Results"
-    }
+  if ($results) {
+    Write-Log -logstring "$($results.ProfileList.Length) Profiles returned out of $($results.TotalResults) total, writing csv." -logfile $Logfile
+  } else {
+    Write-Log -logstring "No Results" -logfile $Logfile
+  }
 }
 catch {
-    Write-Log "Error (maybe no results)  $_"
+  Write-Log -logstring "Error (maybe no results)  $_" -logfile $Logfile
 }
 
 

--- a/Invoke-RebootDevice.ps1
+++ b/Invoke-RebootDevice.ps1
@@ -13,10 +13,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.1
+  Version:        1.2
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  09/30/2020
-  Update Date:    10/02/2021
+  Update Date:    10/08/2021
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Invoke-RebootDevice.ps1 -file "Devices.csv" -fileColumn "SerialNumber"
@@ -38,7 +38,7 @@ $Logfile = "$PSScriptRoot\RebootDevice.log"
 
 $list = Read-FileWithData $file $fileColumn
 
-Write-Log "$($MyInvocation.Line)"
+Write-Log -logstring "$($MyInvocation.Line)" -logfile $Logfile
 
 $decision = $Host.UI.PromptForChoice(
   "Attention! If you proceed, " + @($list).count + " devices will be rebooted",
@@ -46,7 +46,7 @@ $decision = $Host.UI.PromptForChoice(
   @('&Yes', '&No'), 1)
 
 if ($decision -eq 0) {
-  Write-Log "Rebooting $($list.count) devices in AirWatch"
+  Write-Log -logstring "Rebooting $($list.count) devices in AirWatch" -logfile $Logfile
   $devices = @()
   foreach ($item in $list) {
     $devices += $item.$($fileColumn)
@@ -59,21 +59,21 @@ if ($decision -eq 0) {
     if ($result -eq "") {
       $err = ($Error[0].ErrorDetails.Message | ConvertFrom-Json)
       Write-Warning ("Error Rebooting Devices : Error", $err.errorCode, $err.message)
-      Write-Log ("Error Rebooting Devices : Error", $err.errorCode, $err.message)
+      Write-Log -logstring ("Error Rebooting Devices : Error", $err.errorCode, $err.message) -logfile $Logfile
     }
     else {
       Write-Host "$result"
-      Write-Log "$result"
+      Write-Log -logstring "$result" -logfile $Logfile
     }
   }
   catch {
     $err2 = ($Error[0].ErrorDetails.Message)
     Write-Warning "Error Rebooting Devices $err2"
-    Write-Log "Error Rebooting Devices $err2"
+    Write-Log -logstring "Error Rebooting Devices $err2" -logfile $Logfile
   }
 }
 else {
   Write-Host "Action Cancelled"
-  Write-Log "Action Cancelled"
+  Write-Log -logstring "Action Cancelled" -logfile $Logfile
 }
 

--- a/PSairwatch.psm1
+++ b/PSairwatch.psm1
@@ -16,11 +16,11 @@
 .OUTPUTS
   None
 .NOTES
-  Version:        2.12.0
+  Version:        2.12.1
   Author:         Joshua Clark @MrTechGadget
   Source:         https://github.com/MrTechGadget/aw-bulkdevices-script
   Creation Date:  05/22/2018
-  Update Date:    10/02/2021
+  Update Date:    10/08/2021
   
 .EXAMPLE
     $ScriptPath = Split-Path $MyInvocation.MyCommand.Path -Parent
@@ -78,10 +78,13 @@ Function Set-Config {
 
 Function Write-Log
 {
-    Param ([string]$logstring)
+    Param (
+        [string]$logstring,
+        [string]$Logfile = "PSairwatch.log"
+    )
 
     $logstring = ((Get-Date).ToString() + " - " + $logstring)
-    Add-content $Logfile -value $logstring
+    Add-content $logfile -value $logstring
 }
 
 <#  This implementation uses Basic authentication. #>

--- a/Reset-EnterpriseWipe.ps1
+++ b/Reset-EnterpriseWipe.ps1
@@ -13,10 +13,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.1
+  Version:        1.2
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  12/28/2018
-  Updated Date:   10/02/2021
+  Updated Date:   10/08/2021
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Reset-EnterpriseDevice.ps1 -file "Devices.csv" -fileColumn "SerialNumber"
@@ -38,7 +38,7 @@ $Logfile = "$PSScriptRoot\EnterpriseWipe.log"
 
 $list = Read-File $file $fileColumn
 
-Write-Log "$($MyInvocation.Line)"
+Write-Log -logstring "$($MyInvocation.Line)" -logfile $Logfile
 
 $decision = $Host.UI.PromptForChoice(
     "Attention! If you proceed, " + $list.count + " devices will be unenrolled from AirWatch",
@@ -46,7 +46,7 @@ $decision = $Host.UI.PromptForChoice(
     @('&Yes', '&No'), 1)
 
 if ($decision -eq 0) {
-    Write-Log "Wiping $($list.count) devices unenrolled from AirWatch"
+    Write-Log -logstring "Wiping $($list.count) devices unenrolled from AirWatch" -logfile $Logfile
     $json = ' '
 
     foreach ($item in $list) {
@@ -56,22 +56,18 @@ if ($decision -eq 0) {
             $result = Send-Post -endpoint $endpointURL -body $json -version "application/json;version=1"
             if ($result -ne "") {
                 Write-Warning "Error Unenrolling Device: $item :$result"
-                Write-Log "Error Unenrolling Device: $item :$result"
+                Write-Log -logstring "Error Unenrolling Device: $item :$result" -logfile $Logfile
             } else {
                 Write-Host "$item Unenrolled $result"
-                Write-Log "$item Unenrolled $result"
+                Write-Log -logstring "$item Unenrolled $result" -logfile $Logfile
             }
         }
         catch {
             Write-Warning "Error Sending Unenroll Command: $item"
-            Write-Log "Error Sending Unenroll Command: $item"
+            Write-Log -logstring "Error Sending Unenroll Command: $item" -logfile $Logfile
         }
     }
 } else {
     Write-Host "Unenroll Cancelled"
-    Write-Log "Unenroll Cancelled"
+    Write-Log -logstring "Unenroll Cancelled" -logfile $Logfile
 }
-
-
-
-

--- a/Reset-FullDevice.ps1
+++ b/Reset-FullDevice.ps1
@@ -13,10 +13,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.4
+  Version:        1.5
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  10/02/2018
-  Update Date:    10/02/2021
+  Update Date:    10/08/2021
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Reset-FullDevice.ps1 -file "Devices.csv" -fileColumn "SerialNumber"
@@ -38,7 +38,7 @@ $Logfile = "$PSScriptRoot\FullDeviceWipe.log"
 
 $list = Read-File $file $fileColumn
 
-Write-Log "$($MyInvocation.Line)"
+Write-Log -logstring "$($MyInvocation.Line)" -logfile $Logfile
 
 $decision = $Host.UI.PromptForChoice(
     "Attention! If you proceed, " + $list.count + " devices will be Device Wiped back to factory settings from AirWatch",
@@ -46,7 +46,7 @@ $decision = $Host.UI.PromptForChoice(
     @('&Yes', '&No'), 1)
 
 if ($decision -eq 0) {
-    Write-Log "Wiping $($list.count) devices back to factory settings from AirWatch"
+    Write-Log -logstring "Wiping $($list.count) devices back to factory settings from AirWatch" -logfile $Logfile
     $json = '{
         "deviceWipe": {
           "disableActivationKey": true
@@ -66,32 +66,28 @@ if ($decision -eq 0) {
                 if ($result -ne "") {
                   $err = ($Error[0].ErrorDetails.Message | ConvertFrom-Json)
                   Write-Warning ("Error Wiping Device: $item : " + $err.errorCode + " " + $err.message)
-                  Write-Log ("Error Wiping Device: $item : " + $err.errorCode + " " + $err.message)
+                  Write-Log -logstring ("Error Wiping Device: $item : " + $err.errorCode + " " + $err.message) -logfile $Logfile
                 } else {
                   Write-Host "$item Wiped $result"
-                  Write-Log "$item Wiped $result"
+                  Write-Log -logstring "$item Wiped $result" -logfile $Logfile
                 }
               } else {
                 Write-Warning ("Error Wiping Device: $item : Error", $err.errorCode, $err.message)
-                Write-Log ("Error Wiping Device: $item : Error", $err.errorCode, $err.message)
+                Write-Log -logstring ("Error Wiping Device: $item : Error", $err.errorCode, $err.message) -logfile $Logfile
               }
                 
             } else {
                 Write-Host "$item Wiped $result"
-                Write-Log "$item Wiped $result"
+                Write-Log -logstring "$item Wiped $result" -logfile $Logfile
             }
         }
         catch {
           $err2 = ($Error[0].ErrorDetails.Message)
           Write-Warning "Error Sending Device Wipe Command: $item $err2"
-          Write-Log "Error Sending Device Wipe Command: $item $err2"
+          Write-Log -logstring "Error Sending Device Wipe Command: $item $err2" -logfile $Logfile
         }
     }
 } else {
     Write-Host "Deletion Cancelled"
-    Write-Log "Deletion Cancelled"
+    Write-Log -logstring "Deletion Cancelled" -logfile $Logfile
 }
-
-
-
-

--- a/Send-TextMessage.ps1
+++ b/Send-TextMessage.ps1
@@ -15,10 +15,10 @@
 .OUTPUTS
   Outputs a log of actions
 .NOTES
-  Version:        1.1
+  Version:        1.2
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  06/30/2021
-  Update Date:    10/02/2021
+  Update Date:    10/08/2021
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Send-TextMessage.ps1 -file "Devices.csv" -fileColumn "SerialNumber" message "This is the message to be sent"
@@ -42,7 +42,7 @@ $Logfile = "$PSScriptRoot\TextMessage.log"
 
 $list = Read-FileWithData $file $fileColumn
 
-Write-Log "$($MyInvocation.Line)"
+Write-Log -logstring "$($MyInvocation.Line)" -logfile $Logfile
 
 $decision = $Host.UI.PromptForChoice(
     "Attention! If you proceed, " + @($list).count + " devices will be sent this text message through AirWatch: $message",
@@ -50,7 +50,7 @@ $decision = $Host.UI.PromptForChoice(
     @('&Yes', '&No'), 1)
 
 if ($decision -eq 0) {
-    Write-Log "Sending SMS to $($list.count) devices in AirWatch"
+    Write-Log -logstring "Sending SMS to $($list.count) devices in AirWatch" -logfile $Logfile
     $i = 0
     foreach ($item in $list) {
         $i++
@@ -62,20 +62,20 @@ if ($decision -eq 0) {
             if ($result -ne "") {
               $err = ($Error[0].ErrorDetails.Message | ConvertFrom-Json)
               Write-Warning ("Error Sending SMS: $($item.$fileColumn) : Error", $err.errorCode, $err.message)
-              Write-Log ("Error Sending SMS: $($item.$fileColumn) : Error", $err.errorCode, $err.message)
+              Write-Log -logstring ("Error Sending SMS: $($item.$fileColumn) : Error", $err.errorCode, $err.message) -logfile $Logfile
             } else {
                 Write-Host "$($item.$fileColumn) sent $message. $result"
-                Write-Log "$($item.$fileColumn) sent $message. $result"
+                Write-Log -logstring "$($item.$fileColumn) sent $message. $result" -logfile $Logfile
             }
         }
         catch {
           $err2 = ($Error[0].ErrorDetails.Message)
           Write-Warning "Error Sending SMS: $($item.$fileColumn) to $($item.$assetColumn) $err2"
-          Write-Log "Error Sending SMS: $($item.$fileColumn) to $($item.$assetColumn) $err2"
+          Write-Log -logstring "Error Sending SMS: $($item.$fileColumn) to $($item.$assetColumn) $err2" -logfile $Logfile
         }
     }
 } else {
     Write-Host "Action Cancelled"
-    Write-Log "Action Cancelled"
+    Write-Log -logstring "Action Cancelled" -logfile $Logfile
 }
 

--- a/Set-AssetNumber.ps1
+++ b/Set-AssetNumber.ps1
@@ -15,10 +15,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.4
+  Version:        1.5
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  01/14/2020
-  Update Date:    10/02/2021
+  Update Date:    10/08/2021
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Set-AssetNumber.ps1 -file "Devices.csv" -fileColumn "SerialNumber" -assetColumn "AssetNumber"
@@ -42,7 +42,7 @@ $Logfile = "$PSScriptRoot\AssetNumber.log"
 
 $list = Read-FileWithData $file $fileColumn $assetColumn
 
-Write-Log "$($MyInvocation.Line)"
+Write-Log -logstring "$($MyInvocation.Line)" -logfile $Logfile
 
 $decision = $Host.UI.PromptForChoice(
     "Attention! If you proceed, " + @($list).count + " devices will have their AssetNumber overwritten in AirWatch",
@@ -50,7 +50,7 @@ $decision = $Host.UI.PromptForChoice(
     @('&Yes', '&No'), 1)
 
 if ($decision -eq 0) {
-    Write-Log "Replacing asset numbers on $($list.count) devices in AirWatch"
+    Write-Log -logstring "Replacing asset numbers on $($list.count) devices in AirWatch" -logfile $Logfile
     $i = 0
     foreach ($item in $list) {
         $i++
@@ -62,20 +62,19 @@ if ($decision -eq 0) {
             if ($result -ne "") {
               $err = ($Error[0].ErrorDetails.Message | ConvertFrom-Json)
               Write-Warning ("Error Setting AssetNumber: $($item.$fileColumn) : Error", $err.errorCode, $err.message)
-              Write-Log ("Error Setting AssetNumber: $($item.$fileColumn) : Error", $err.errorCode, $err.message)
+              Write-Log -logstring ("Error Setting AssetNumber: $($item.$fileColumn) : Error", $err.errorCode, $err.message) -logfile $Logfile
             } else {
                 Write-Host "$($item.$fileColumn) set to $($item.$assetColumn) $result"
-                Write-Log "$($item.$fileColumn) set to $($item.$assetColumn) $result"
+                Write-Log -logstring "$($item.$fileColumn) set to $($item.$assetColumn) $result" -logfile $Logfile
             }
         }
         catch {
           $err2 = ($Error[0].ErrorDetails.Message)
           Write-Warning "Error Setting AssetNumber: $($item.$fileColumn) to $($item.$assetColumn) $err2"
-          Write-Log "Error Setting AssetNumber: $($item.$fileColumn) to $($item.$assetColumn) $err2"
+          Write-Log -logstring "Error Setting AssetNumber: $($item.$fileColumn) to $($item.$assetColumn) $err2" -logfile $Logfile
         }
     }
 } else {
     Write-Host "Action Cancelled"
-    Write-Log "Action Cancelled"
+    Write-Log -logstring "Action Cancelled" -logfile $Logfile
 }
-

--- a/Set-CheckoutDevice.ps1
+++ b/Set-CheckoutDevice.ps1
@@ -15,10 +15,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.1
+  Version:        1.2
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  01/11/2021
-  Update Date:    10/02/2021
+  Update Date:    10/08/2021
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Set-CheckoutDevice.ps1 -file "Devices.csv" -deviceColumn "DeviceId" -userColumn "UserId"
@@ -41,7 +41,7 @@ $Logfile = "$PSScriptRoot\Checkout.log"
 
 $list = Read-FileWithData $file $deviceColumn $userColumn
 
-Write-Log "$($MyInvocation.Line)"
+Write-Log -logstring "$($MyInvocation.Line)" -logfile $Logfile
 
 $decision = $Host.UI.PromptForChoice(
     "Attention! If you proceed, " + @($list).count + " devices will be assigned to the corresponding user identified in this file in AirWatch",
@@ -49,7 +49,7 @@ $decision = $Host.UI.PromptForChoice(
     @('&Yes', '&No'), 1)
 
 if ($decision -eq 0) {
-    Write-Log "Assigning to users on $($list.count) devices in AirWatch"
+    Write-Log -logstring "Assigning to users on $($list.count) devices in AirWatch" -logfile $Logfile
     $i = 0
     foreach ($item in $list) {
         $i++
@@ -60,20 +60,19 @@ if ($decision -eq 0) {
             if ($result -ne "") {
               $err = ($Error[0].ErrorDetails.Message | ConvertFrom-Json)
               Write-Warning ("Error Assigning DeviceName: $($item.$deviceColumn) : Error", $err.errorCode, $err.message)
-              Write-Log ("Error Assigning DeviceName: $($item.$deviceColumn) : Error", $err.errorCode, $err.message)
+              Write-Log -logstring ("Error Assigning DeviceName: $($item.$deviceColumn) : Error", $err.errorCode, $err.message) -logfile $Logfile
             } else {
                 Write-Host "$($item.$deviceColumn) assigned to $($item.$userColumn) $result"
-                Write-Log "$($item.$deviceColumn) assigned to $($item.$userColumn) $result"
+                Write-Log -logstring "$($item.$deviceColumn) assigned to $($item.$userColumn) $result" -logfile $Logfile
             }
         }
         catch {
           $err2 = ($Error[0].ErrorDetails.Message | ConvertFrom-Json)
           Write-Warning "Error Assigning DeviceName: $($item.$deviceColumn) to $($item.$userColumn) $err2"
-          Write-Log "Error Assigning DeviceName: $($item.$deviceColumn) to $($item.$userColumn) $err2"
+          Write-Log -logstring "Error Assigning DeviceName: $($item.$deviceColumn) to $($item.$userColumn) $err2" -logfile $Logfile
         }
     }
 } else {
     Write-Host "Action Cancelled"
-    Write-Log "Action Cancelled"
+    Write-Log -logstring "Action Cancelled" -logfile $Logfile
 }
-

--- a/Set-DeviceName.ps1
+++ b/Set-DeviceName.ps1
@@ -15,10 +15,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.1
+  Version:        1.2
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  01/15/2020
-  Update Date:    10/02/2021
+  Update Date:    10/08/2021
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Set-DeviceName.ps1 -file "Devices.csv" -fileColumn "SerialNumber" -deviceColumn "DeviceName"
@@ -42,7 +42,7 @@ $Logfile = "$PSScriptRoot\DeviceName.log"
 
 $list = Read-FileWithData $file $fileColumn $deviceColumn
 
-Write-Log "$($MyInvocation.Line)"
+Write-Log -logstring "$($MyInvocation.Line)" -logfile $Logfile
 
 $decision = $Host.UI.PromptForChoice(
     "Attention! If you proceed, " + @($list).count + " devices will have their DeviceName overwritten in AirWatch",
@@ -50,7 +50,7 @@ $decision = $Host.UI.PromptForChoice(
     @('&Yes', '&No'), 1)
 
 if ($decision -eq 0) {
-    Write-Log "Replacing DeviceName on $($list.count) devices in AirWatch"
+    Write-Log -logstring "Replacing DeviceName on $($list.count) devices in AirWatch" -logfile $Logfile
     $i = 0
     foreach ($item in $list) {
         $i++
@@ -63,20 +63,19 @@ if ($decision -eq 0) {
             if ($result -ne "") {
               $err = ($Error[0].ErrorDetails.Message | ConvertFrom-Json)
               Write-Warning ("Error Setting DeviceName: $($item.$fileColumn) : Error", $err.errorCode, $err.message)
-              Write-Log ("Error Setting DeviceName: $($item.$fileColumn) : Error", $err.errorCode, $err.message)
+              Write-Log -logstring ("Error Setting DeviceName: $($item.$fileColumn) : Error", $err.errorCode, $err.message) -logfile $Logfile
             } else {
                 Write-Host "$($item.$fileColumn) set to $($item.$deviceColumn) $result"
-                Write-Log "$($item.$fileColumn) set to $($item.$deviceColumn) $result"
+                Write-Log -logstring "$($item.$fileColumn) set to $($item.$deviceColumn) $result" -logfile $Logfile
             }
         }
         catch {
           $err2 = ($Error[0].ErrorDetails.Message)
           Write-Warning "Error Setting DeviceName: $($item.$fileColumn) to $($item.$deviceColumn) $err2"
-          Write-Log "Error Setting DeviceName: $($item.$fileColumn) to $($item.$deviceColumn) $err2"
+          Write-Log -logstring "Error Setting DeviceName: $($item.$fileColumn) to $($item.$deviceColumn) $err2" -logfile $Logfile
         }
     }
 } else {
     Write-Host "Action Cancelled"
-    Write-Log "Action Cancelled"
+    Write-Log -logstring "Action Cancelled" -logfile $Logfile
 }
-


### PR DESCRIPTION
The Write-Log refactor created an unexpected error due to the function not being sent a file name.

This fixes that error on all scripts that write logs.