### PR TITLE
Added Invocation Logging to every script

### DIFF
--- a/Delete-Device.ps1
+++ b/Delete-Device.ps1
@@ -13,10 +13,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.1
+  Version:        1.2
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  10/02/2021
-  Updated Date:   10/08/2021
+  Updated Date:   10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Delete-Device.ps1 -file "Devices.csv" -fileColumn "SerialNumber"
@@ -33,6 +33,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 $Logfile = "$PSScriptRoot\DeleteDevice.log"
 $list = Read-File $file $fileColumn

--- a/Delete-Profile.ps1
+++ b/Delete-Profile.ps1
@@ -13,10 +13,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.2
+  Version:        1.3
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  01/09/2021
-  Update Date:    10/08/2021
+  Update Date:    10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   Delete-Profile.ps1 -file .\ProfilesTest.csv -fileColumn "ProfileId"
@@ -33,6 +33,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 $Logfile = "$PSScriptRoot\ProfileDelete.log"
 

--- a/Delete-StaleDevices.ps1
+++ b/Delete-StaleDevices.ps1
@@ -11,10 +11,10 @@
 .OUTPUTS
   Outputs a CSV file with Devices that have not been seen in X number of days that have been deleted.
 .NOTES
-  Version:        1.7
+  Version:        1.8
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  09/15/2017
-  Last Updated:   11/14/2019
+  Last Updated:   10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   Delete-StaleDevices.ps1 -pageSize 1000 -maxLastSeen 250
@@ -29,7 +29,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
-
+Write-Log -logstring "$($MyInvocation.Line)"
 
 $OrgGroups = Get-OrgGroups
 $GroupID = Select-Tag $OrgGroups

--- a/Delete-User.ps1
+++ b/Delete-User.ps1
@@ -13,10 +13,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.1
+  Version:        1.3
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  07/02/2018
-  Update Date:    12/28/2018
+  Update Date:    10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Delete-User.ps1 -userFile "User.csv" -userFileColumn "Id.Value"
@@ -33,6 +33,8 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
+
 $batchsize = 50
 $userList = Read-File $userFile $userFileColumn
 $splitUserList = Split-Array -inArray $userList -size $batchsize

--- a/Get-DeviceDetails.ps1
+++ b/Get-DeviceDetails.ps1
@@ -15,10 +15,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.2
+  Version:        1.3
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  01/08/2021
-  Update Date:    10/08/2021
+  Update Date:    10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Get-DeviceDetails.ps1 -file "Devices.csv" -fileColumn "SerialNumber"
@@ -38,6 +38,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 $Logfile = "$PSScriptRoot\DeviceDetails.log"
 

--- a/Get-ListOfStaleDevices.ps1
+++ b/Get-ListOfStaleDevices.ps1
@@ -10,11 +10,11 @@
 .OUTPUTS
   Outputs a CSV file with Devices that have not been seen in X number of days.
 .NOTES
-  Version:        1.3
-  Author:         Joshua Clark @audioeng
+  Version:        1.4
+  Author:         Joshua Clark @MrTechGadget
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
   Creation Date:  09/15/2017
-  Last Update:    11/14/2019
+  Last Update:    10/13/2022
 .EXAMPLE
   Get-ListOfStaleDevices.ps1 -pageSize 1000 -maxLastSeen 250
 #>
@@ -28,6 +28,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 Function Set-DeviceIdList {
   Param([object]$Devices)

--- a/Get-ListOfTaggedDevices.ps1
+++ b/Get-ListOfTaggedDevices.ps1
@@ -24,10 +24,10 @@
 .OUTPUTS
   Outputs a CSV file with Devices that have the selected tag.
 .NOTES
-  Version:        1.4
+  Version:        1.5
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  09/06/2017
-  Update Date:    07/30/2021
+  Update Date:    10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
   
 .EXAMPLE
@@ -35,6 +35,7 @@
 #>
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 <# Start of Script #>
 $TagList = Get-Tags

--- a/Get-Profile.ps1
+++ b/Get-Profile.ps1
@@ -12,10 +12,10 @@
 .OUTPUTS
   Outputs a CSV: "Profiles[today's date].csv"
 .NOTES
-  Version:        1.2
+  Version:        1.3
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  01/09/2021
-  Update Date:    10/08/2021
+  Update Date:    10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Get-Profile.ps1 -query "status=Active&platform=Apple"
@@ -29,6 +29,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 $Logfile = "$PSScriptRoot\Profiles.log"
 

--- a/Install-Application.ps1
+++ b/Install-Application.ps1
@@ -9,10 +9,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.1
+  Version:        1.2
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  4/20/2021
-  Update Date:    10/12/2021
+  Update Date:    10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   Install-Application.ps1 -file .\Devices.csv -fileColumn "device_id" -appId "12345" -appType "purchased"
@@ -31,11 +31,11 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 <#
 Start of Script
 #>
-Write-Log "$($MyInvocation.Line)"
 
 $devicelist = Read-File $file $fileColumn
 #$OrgGroups = Get-OrgGroups

--- a/Install-HungProfile.ps1
+++ b/Install-HungProfile.ps1
@@ -9,10 +9,11 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.3
-  Author:         Joshua Clark @audioeng
+  Version:        1.4
+  Author:         Joshua Clark @MrTechGadget
   Creation Date:  10/8/2019
-  Site:           https://github.com/audioeng/aw-bulkdevices-script
+  Update Date:    10/13/2022
+  Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   Install-HungProfile.ps1 -serialFile .\Serials.csv
 #>
@@ -27,6 +28,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 <#
 Start of Script

--- a/Invoke-RebootDevice.ps1
+++ b/Invoke-RebootDevice.ps1
@@ -13,10 +13,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.2
+  Version:        1.3
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  09/30/2020
-  Update Date:    10/08/2021
+  Update Date:    10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Invoke-RebootDevice.ps1 -file "Devices.csv" -fileColumn "SerialNumber"
@@ -33,6 +33,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 $Logfile = "$PSScriptRoot\RebootDevice.log"
 

--- a/Query-Device.ps1
+++ b/Query-Device.ps1
@@ -9,7 +9,7 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.1
+  Version:        1.2
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  4/21/2021
   Update Date:    10/13/2022

--- a/Query-Device.ps1
+++ b/Query-Device.ps1
@@ -12,7 +12,7 @@
   Version:        1.1
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  4/21/2021
-  Update Date:    10/08/2021
+  Update Date:    10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   Query-Device.ps1 -file .\devices.csv -fileColumn "device_id"
@@ -32,6 +32,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 <#
 Start of Script

--- a/Remove-StaleDevices.ps1
+++ b/Remove-StaleDevices.ps1
@@ -12,10 +12,10 @@
 .OUTPUTS
   Outputs two CSV files with Devices that have not been seen in X number of days. One that are supervised, one that are unsupervised.
 .NOTES
-  Version:        1.7
+  Version:        1.8
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  09/15/2017
-  Last Updated:   11/14/2019
+  Last Updated:   10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
   
 .EXAMPLE
@@ -31,7 +31,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
-
+Write-Log -logstring "$($MyInvocation.Line)"
 
 $OrgGroups = Get-OrgGroups
 $GroupID = Select-Tag $OrgGroups

--- a/Reset-EnterpriseWipe.ps1
+++ b/Reset-EnterpriseWipe.ps1
@@ -13,10 +13,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.2
+  Version:        1.3
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  12/28/2018
-  Updated Date:   10/08/2021
+  Updated Date:   10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Reset-EnterpriseDevice.ps1 -file "Devices.csv" -fileColumn "SerialNumber"
@@ -33,6 +33,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 $Logfile = "$PSScriptRoot\EnterpriseWipe.log"
 

--- a/Reset-FullDevice.ps1
+++ b/Reset-FullDevice.ps1
@@ -13,10 +13,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.5
+  Version:        1.6
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  10/02/2018
-  Update Date:    10/08/2021
+  Update Date:    10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Reset-FullDevice.ps1 -file "Devices.csv" -fileColumn "SerialNumber"
@@ -33,6 +33,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 $Logfile = "$PSScriptRoot\FullDeviceWipe.log"
 

--- a/Send-TextMessage.ps1
+++ b/Send-TextMessage.ps1
@@ -18,7 +18,7 @@
   Version:        1.2
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  06/30/2021
-  Update Date:    10/08/2021
+  Update Date:    10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Send-TextMessage.ps1 -file "Devices.csv" -fileColumn "SerialNumber" message "This is the message to be sent"
@@ -37,6 +37,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 $Logfile = "$PSScriptRoot\TextMessage.log"
 

--- a/Send-TextMessage.ps1
+++ b/Send-TextMessage.ps1
@@ -15,7 +15,7 @@
 .OUTPUTS
   Outputs a log of actions
 .NOTES
-  Version:        1.2
+  Version:        1.3
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  06/30/2021
   Update Date:    10/13/2022

--- a/Set-AssetNumber.ps1
+++ b/Set-AssetNumber.ps1
@@ -15,10 +15,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.5
+  Version:        1.6
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  01/14/2020
-  Update Date:    10/08/2021
+  Update Date:    10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Set-AssetNumber.ps1 -file "Devices.csv" -fileColumn "SerialNumber" -assetColumn "AssetNumber"
@@ -37,6 +37,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 $Logfile = "$PSScriptRoot\AssetNumber.log"
 

--- a/Set-CheckoutDevice.ps1
+++ b/Set-CheckoutDevice.ps1
@@ -15,10 +15,10 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.2
+  Version:        1.3
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  01/11/2021
-  Update Date:    10/08/2021
+  Update Date:    10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Set-CheckoutDevice.ps1 -file "Devices.csv" -deviceColumn "DeviceId" -userColumn "UserId"
@@ -36,6 +36,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 $Logfile = "$PSScriptRoot\Checkout.log"
 

--- a/Set-DeviceName.ps1
+++ b/Set-DeviceName.ps1
@@ -15,7 +15,7 @@
 .OUTPUTS
   NO OUTPUT CURRENTLY:Outputs a CSV log of actions
 .NOTES
-  Version:        1.2
+  Version:        1.3
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  01/15/2020
   Update Date:    10/13/2022

--- a/Set-DeviceName.ps1
+++ b/Set-DeviceName.ps1
@@ -18,7 +18,7 @@
   Version:        1.2
   Author:         Joshua Clark @MrTechGadget
   Creation Date:  01/15/2020
-  Update Date:    10/08/2021
+  Update Date:    10/13/2022
   Site:           https://github.com/MrTechGadget/aw-bulkdevices-script
 .EXAMPLE
   .\Set-DeviceName.ps1 -file "Devices.csv" -fileColumn "SerialNumber" -deviceColumn "DeviceName"
@@ -37,6 +37,7 @@ Param(
 )
 
 Import-Module .\PSairwatch.psm1
+Write-Log -logstring "$($MyInvocation.Line)"
 
 $Logfile = "$PSScriptRoot\DeviceName.log"
 


### PR DESCRIPTION
To improve consistency of logging, I have added a log of every invocation to each script to the base PSairwatch.log file. Many scripts also log results to other files, that feature remains untouched.